### PR TITLE
feat: implement custom view for login page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,23 @@
 class ApplicationController < ActionController::Base
+  layout :determine_layout
+
+  private 
+
+  def determine_layout
+    if !user_signed_in? && sign_in_or_sign_up_or_forgot_password_action?
+      "unauth"
+    else
+      "application"
+    end
+  end
+
+  def sign_in_or_sign_up_or_forgot_password_action?
+    return true if params[:controller] == "devise/sessions" && params[:action] == "new"
+
+    return true if params[:controller] == "users/registrations" && params[:action] == "new"
+
+    return true if params[:controller] == "devise/passwords" && params[:action] == "new"
+
+    return false 
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,2 +1,6 @@
 class PagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
 end

--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["message"]
+
+  connect() {
+    if (this.hasMessageTarget) {
+      setTimeout(() => {
+        this.closeMessage()
+      }, 5000)
+    }
+  }
+
+  closeMessage() {
+    this.messageTarget.classList.add('opacity-0')
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,33 @@
+<div class="w-full max-w-lg mx-auto bg-white shadow-lg p-6 mt-10">
+  <h1 class="text-2xl text-center font-semibold mb-6">Sign In</h1>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <div class="field text-sm">
+      <%= f.label :email, class: "block font-medium text-gray-900 mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "text-sm w-full bg-gray-50 border border-gray-300 text-gray-900 rounded-lg p-2.5", placeholder: "name@company.com" %>
+    </div>
+
+    <div class="field text-sm">
+      <%= f.label :password, class: "block font-medium text-gray-900 mb-2" %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "text-sm w-full bg-gray-50 border border-gray-300 text-gray-900 rounded-lg p-2.5", placeholder: "******" %>
+    </div>
+
+    <div class="flex justify-between">
+      <% if devise_mapping.rememberable? %>
+        <div class="flex items-center mb-4">
+          <%= f.check_box :remember_me, class: "w-4 h-4 text-blue-600 bg-gray-100 border border-gray-300 rounded" %>
+          <%= f.label :remember_me, class: "ms-2 text-sm text-gray-900" %>
+        </div>
+      <% end %>
+      <%= link_to "Forgot your password?", new_password_path(resource_name), class: "text-sm italic text-gray-400 font-light hover:text-gray-900" %>
+    </div>
+    
+    <%= f.submit "Sign In", class: "text-sm bg-blue-600 text-white w-full px-5 py-2.5 rounded-lg hover:cursor-pointer hover:bg-blue-700" %>
+  <% end %>
+  <p class="text-gray-500 mt-5 text-xs text-center">
+    Don't have an account?
+    <span>
+      <%= link_to "Sign up", new_registration_path(resource_name), class: "text-blue-600 hover:underline" %>
+    </span>
+  </p>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false" class="text-sm text-red-800 bg-red-50 p-4 rounded-lg border border-red-300">
+  <div id="error_explanation" data-turbo-cache="false" class="text-sm text-red-800 bg-red-100 p-4 rounded-lg border border-red-300">
     <h2 class="text-red-900 font-medium mb-1">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/app/views/layouts/unauth.html.erb
+++ b/app/views/layouts/unauth.html.erb
@@ -12,11 +12,8 @@
   </head>
   <body class="bg-gray-50">
     <%= render "shared/flash_message" %>
-    <nav class="bg-cyan-200 h-16">
-      Going to implement this navbar later
-      <% if user_signed_in? %>
-        <%= link_to "Sign out", destroy_user_session_path, data: { turbo_method: :delete } %>
-      <% end %>
+    <nav class="bg-pink-200 h-16">
+      Going to implement this UNAUTH navbar later
     </nav>
     <%= yield %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,25 @@
+<%-   
+  alert_classes = {
+    "notice" => "bg-blue-100 text-blue-800 border border-blue-300",
+    "alert" => "bg-red-100 text-red-800 border border-red-300"
+  }
+
+  close_button_classes = {
+    "notice" => "hover:bg-blue-200",
+    "alert" => "hover:bg-red-200"
+  
+  }
+%>
+
+<div data-controller="flash-message">
+  <% flash.each do |key, value| %>
+  <div data-flash-message-target="message" class="fixed flex justify-between items-center h-auto top-5 shadow-lg right-5 left-5 md:left-auto md:min-w-96 p-4 text-sm rounded-lg transition-opacity ease-out duration-300 <%= alert_classes[key] %>" role="<%= key %>">
+    <span class="font-medium"><%= value %></span>
+    <button class="ml-3 p-1 rounded-lg <%= close_button_classes[key] %>" data-action="click->flash-message#closeMessage"">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+  <% end %>
+</div>


### PR DESCRIPTION
- Use 'unauth' layout for sign_in/sign_up/forgot_password pages
- Implement flash message with close button and auto hide after 5 seconds
<img width="1069" alt="Screenshot 2024-05-07 at 13 06 17" src="https://github.com/hienvl125/rails-ecommerce/assets/40386066/4451ffcd-2474-4d99-ade4-c8b8fd310e05">


